### PR TITLE
Bump Iceberg to 1.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,16 +3,9 @@ plugins {
   id 'com.github.johnrengelman.shadow' version '7.1.2'
 }
 
-repositories {
-  mavenCentral()
-  maven {
-    url "https://repository.apache.org/content/repositories/snapshots"
-  }
-}
-
 ext {
-  icebergVersion = '0.15.0-SNAPSHOT'
-  awsSdkVersion = '2.17.243'
+  icebergVersion = '1.1.0'
+  awsSdkVersion = '2.17.257'
 }
 
 dependencies {


### PR DESCRIPTION
Seeing some weird errors when writing integration tests for Python:
```
pyiceberg-rest   | org.apache.iceberg.exceptions.RESTException: Unhandled error: ErrorResponse(code=406, type=UnsupportedOperationException, message=Not implemented)
pyiceberg-rest   | java.lang.UnsupportedOperationException: Not implemented
pyiceberg-rest   | 	at org.apache.iceberg.MetadataUpdate$AssignUUID.applyTo(MetadataUpdate.java:44)
pyiceberg-rest   | 	at org.apache.iceberg.rest.CatalogHandlers.lambda$create$2(CatalogHandlers.java:305)
pyiceberg-rest   | 	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
pyiceberg-rest   | 	at org.apache.iceberg.rest.CatalogHandlers.create(CatalogHandlers.java:305)
pyiceberg-rest   | 	at org.apache.iceberg.rest.CatalogHandlers.updateTable(CatalogHandlers.java:256)
pyiceberg-rest   | 	at org.apache.iceberg.rest.RESTCatalogAdapter.handleRequest(RESTCatalogAdapter.java:331)
pyiceberg-rest   | 	at org.apache.iceberg.rest.RESTCatalogAdapter.execute(RESTCatalogAdapter.java:365)
pyiceberg-rest   | 	at org.apache.iceberg.rest.RESTCatalogServlet.execute(RESTCatalogServlet.java:100)
pyiceberg-rest   | 	at org.apache.iceberg.rest.RESTCatalogServlet.doPost(RESTCatalogServlet.java:78)
pyiceberg-rest   | 	at javax.servlet.http.HttpServlet.service(HttpServlet.java:707)
pyiceberg-rest   | 	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
pyiceberg-rest   | 	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:799)
pyiceberg-rest   | 	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:550)
pyiceberg-rest   | 	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143)
pyiceberg-rest   | 	at org.eclipse.jetty.server.handler.gzip.GzipHandler.handle(GzipHandler.java:713)
pyiceberg-rest   | 	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
```

I think this is because we're on an old version of Iceberg for the catalog