### PR TITLE
Update latest tag when image is pushed

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -45,5 +45,5 @@ jobs:
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: tabulario/iceberg-rest:${{ inputs.tag }}
+          tags: tabulario/iceberg-rest:latest,tabulario/iceberg-rest:${{ inputs.tag }}
 


### PR DESCRIPTION
https://hub.docker.com/r/tabulario/iceberg-rest/tags shows that 0.2.0 has the latest changes, but `latest` still points to 0.1.0