### PR TITLE
Support for HiveMetastore catalog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,10 @@ RUN \
 
 COPY --from=builder --chown=iceberg:iceberg /app/build/libs/iceberg-rest-image-all.jar /usr/lib/iceberg-rest/iceberg-rest-image-all.jar
 
-ENV CATALOG_CATALOG__IMPL=org.apache.iceberg.jdbc.JdbcCatalog
+ENV CATALOG_CATALOG__IMPL=org.apache.iceberg.jdbc.JdbcCatalog 
+# For HiveMetastore the environment variable - org.apache.iceberg.hive.HiveCatalog
 ENV CATALOG_URI=jdbc:sqlite:file:/tmp/iceberg_rest_mode=memory
+# For HMS URI thrift://hms_url:9083
 ENV CATALOG_JDBC_USER=user
 ENV CATALOG_JDBC_PASSWORD=password
 ENV REST_PORT=8181

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
   implementation "org.apache.iceberg:iceberg-bundled-guava:${icebergVersion}"
 
   implementation "org.apache.hadoop:hadoop-common:${hadoopVersion}"
+  implementation "org.apache.hadoop:hadoop-aws:${hadoopVersion}"
   implementation "org.apache.hadoop:hadoop-hdfs-client:${hadoopVersion}"
 
   runtimeOnly "org.apache.iceberg:iceberg-aws-bundle:${icebergVersion}"
@@ -51,6 +52,19 @@ dependencies {
 
   implementation 'org.xerial:sqlite-jdbc:3.45.3.0'
   implementation 'org.postgresql:postgresql:42.7.2'
+
+  //Adding S3FileIO dependency
+  implementation(platform('software.amazon.awssdk:bom:2.21.1'))
+  implementation('software.amazon.awssdk:s3')
+  //Adding Hive Metastore Catalog dependency
+  implementation "org.apache.iceberg:iceberg-hive-metastore:${icebergVersion}"
+  implementation "org.apache.hive:hive-metastore:3.1.3"
+  implementation "org.apache.hadoop:hadoop-mapreduce-client-core:${hadoopVersion}"
+  constraints {
+    implementation('org.eclipse.jetty:jetty-servlet:9.4.52.v20230823') {
+        because 'backwards incompatible changes in earlier versions'
+    }
+  }
 }
 
 jar {


### PR DESCRIPTION
This will extend support of REST interface to HiveMetastore catalog. Also added dependency for S3 object storage access to fix the 403 forbidden issue while creating new table backed with S3 location. 

This will resolve the issue 
https://github.com/tabular-io/iceberg-rest-image/issues/84